### PR TITLE
Use xmlNode in poemUtils conversion error messages

### DIFF
--- a/src/poem/poemUtils.py
+++ b/src/poem/poemUtils.py
@@ -51,7 +51,7 @@ def convertStringToFloat(xmlNode):
     val = float(xmlNode.text)
     return val
   except (ValueError,TypeError):
-    raise IOError('Real value is required for content of node %s, but got %s' %(node.tag, node.text))
+    raise IOError('Real value is required for content of node %s, but got %s' %(xmlNode.tag, xmlNode.text))
 
 def convertStringToInt(xmlNode):
   """
@@ -63,7 +63,7 @@ def convertStringToInt(xmlNode):
     val = int(xmlNode.text)
     return val
   except (ValueError,TypeError):
-    raise IOError('Integer value is required for content of node %s, but got %s' %(node.tag, node.text))
+    raise IOError('Integer value is required for content of node %s, but got %s' %(xmlNode.tag, xmlNode.text))
 
 def toString(s):
   """


### PR DESCRIPTION
Both `convertStringToFloat` and `convertStringToInt` in `src/poem/poemUtils.py` build their `IOError` from `node.tag` and `node.text`, but the parameter is called `xmlNode` and nothing named `node` is in scope. So the error path never produces the intended message:

```
>>> convertStringToFloat(ET.fromstring("<maxIter>not_a_number</maxIter>"))
NameError: name 'node' is not defined
```

After the rename it does what the message was written to do:

```
OSError: Real value is required for content of node maxIter, but got not_a_number
```

Valid input is unaffected (`3.14` and `7` still come back as before).

To be straight about scope: neither helper is called anywhere else in POEM today, so this is not fixing a crash in a shipping workflow. They are public module-level utilities though, and the handler is simply broken as written, so it seemed worth correcting before something does call them. I did not add a test since the repo tests are RAVEN XML runs rather than unit tests, but I am glad to add one if you have a place for it.